### PR TITLE
Add a separate bot initializer method

### DIFF
--- a/mediawiki/bot.py
+++ b/mediawiki/bot.py
@@ -7,7 +7,12 @@ import datetime
 
 class Bot(object):
 
-    def __init__(self, url, username, password):
+    def __init__(self, *args):
+        if len(args) == 3:
+            url, username, password = args
+            self.init(url, username, password)
+
+    def init(self, url, username, password):
         self.url = url
         self.username = username
         self.password = password


### PR DESCRIPTION
Add a separate bot initializer method so that the bot
can be initialized with no parameters, and initialized
later with the base wiki URL, username and password.