### PR TITLE
Add a try catch block to the response parsing section of the login me…

### DIFF
--- a/mediawiki/bot.py
+++ b/mediawiki/bot.py
@@ -51,8 +51,11 @@ class Bot(object):
                 "password": self.password
             })
         data = response.json()
-        if data["clientlogin"]["status"] == "PASS":
-            print "Logged in as {}".format(data["clientlogin"]["username"])
+        try:
+            if data["clientlogin"]["status"] == "PASS":
+                print "Logged in as {}".format(data["clientlogin"]["username"])
+        except:
+            print "Error parsing response: ", data
 
     def edit(self):
         api_url = "{}/api.php?action=query&meta=tokens&format=json".format(self.url)


### PR DESCRIPTION
…thod

Add a try catch block to the response parsing section of the login method
in order to log the contents of the response. This method intermittently
fails in production, and without logging the contents in the response
it is unclear why that is happening.